### PR TITLE
Add WithBody() function -- Issue #11

### DIFF
--- a/test/server.go
+++ b/test/server.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"encoding/json"
 	"github.com/brandonromano/wrecker/test/models"
 	"github.com/julienschmidt/httprouter"
 	"net"
@@ -47,43 +48,74 @@ func PostUser(writer http.ResponseWriter, request *http.Request, params httprout
 	response := new(models.Response).Init()
 	defer response.Output(writer)
 
-	id, err := strconv.Atoi(request.FormValue("id"))
-	userName := request.FormValue("user_name")
-	location := request.FormValue("location")
-	if err != nil || len(userName) == 0 || len(location) == 0 {
-		response.StatusCode = http.StatusBadRequest
-		return
-	}
+	// Special handling for REST/JSON encoding
+	if request.Header.Get("Content-Type") == "application/json" {
 
-	user := models.User{
-		Id:       id,
-		UserName: userName,
-		Location: location,
+		user := new(models.User)
+
+		if err := json.NewDecoder(request.Body).Decode(&user); err != nil {
+			response.StatusCode = http.StatusBadRequest
+			response.Content = err.Error()
+			return
+		}
+
+		response.Content = user
+
+	} else { // Otherwise, standard handling for Form post
+
+		id, err := strconv.Atoi(request.FormValue("id"))
+		userName := request.FormValue("user_name")
+		location := request.FormValue("location")
+		if err != nil || len(userName) == 0 || len(location) == 0 {
+			response.StatusCode = http.StatusBadRequest
+			return
+		}
+
+		user := models.User{
+			Id:       id,
+			UserName: userName,
+			Location: location,
+		}
+		response.Content = user
 	}
-	response.Content = user
 }
 
 func PutUser(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {
 	response := new(models.Response).Init()
 	defer response.Output(writer)
 
-	id, err := strconv.Atoi(request.FormValue("id"))
-	userName := request.FormValue("user_name")
-	location := request.FormValue("location")
-	if err != nil || len(userName) == 0 && len(location) == 0 {
-		response.StatusCode = http.StatusBadRequest
-		return
-	}
+	if request.Header.Get("Content-Type") == "application/json" {
 
-	user := new(models.User).Load(id)
-	if len(userName) > 0 {
-		user.UserName = userName
-	}
-	if len(location) > 0 {
-		user.Location = location
-	}
+		user := new(models.User)
 
-	response.Content = user
+		if err := json.NewDecoder(request.Body).Decode(&user); err != nil {
+			response.StatusCode = http.StatusBadRequest
+			response.Content = err.Error()
+			return
+		}
+
+		response.Content = user
+
+	} else {
+
+		id, err := strconv.Atoi(request.FormValue("id"))
+		userName := request.FormValue("user_name")
+		location := request.FormValue("location")
+		if err != nil || len(userName) == 0 && len(location) == 0 {
+			response.StatusCode = http.StatusBadRequest
+			return
+		}
+
+		user := new(models.User).Load(id)
+		if len(userName) > 0 {
+			user.UserName = userName
+		}
+		if len(location) > 0 {
+			user.Location = location
+		}
+
+		response.Content = user
+	}
 }
 
 func DeleteUser(writer http.ResponseWriter, request *http.Request, params httprouter.Params) {

--- a/test/wrecker_test.go
+++ b/test/wrecker_test.go
@@ -1,8 +1,8 @@
 package test
 
 import (
-	"github.com/brandonromano/wrecker"
-	"github.com/brandonromano/wrecker/test/models"
+	"github.com/benpate/wrecker"
+	"github.com/benpate/wrecker/test/models"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
@@ -158,4 +158,60 @@ func TestFailDelete(t *testing.T) {
 	}
 
 	assert.True(t, !response.Success)
+}
+
+func TestRestPost(t *testing.T) {
+
+	response := models.Response{
+		Content: new(models.User),
+	}
+
+	userIn := models.User{
+		Id:       98,
+		UserName: "Steve Rogers",
+		Location: "New York, NY",
+	}
+
+	err := wreckerClient.Post("/users").
+		WithBody(userIn).
+		Into(&response).
+		Execute()
+
+	assert.True(t, err == nil)
+	assert.True(t, response.Success)
+
+	userOut, ok := response.Content.(*models.User)
+
+	assert.True(t, ok)
+	assert.True(t, userOut.Id == 98)
+	assert.True(t, userOut.UserName == "Steve Rogers")
+	assert.True(t, userOut.Location == "New York, NY")
+}
+
+func TestRestPut(t *testing.T) {
+
+	response := models.Response{
+		Content: new(models.User),
+	}
+
+	userIn := models.User{
+		Id:       99,
+		UserName: "Natasha Romanov",
+		Location: "New York, NY",
+	}
+
+	err := wreckerClient.Put("/users").
+		WithBody(userIn).
+		Into(&response).
+		Execute()
+
+	assert.True(t, err == nil)
+	assert.True(t, response.Success)
+
+	userOut, ok := response.Content.(*models.User)
+
+	assert.True(t, ok)
+	assert.True(t, userOut.Id == 99)
+	assert.True(t, userOut.UserName == "Natasha Romanov")
+	assert.True(t, userOut.Location == "New York, NY")
 }

--- a/wrecker.go
+++ b/wrecker.go
@@ -1,7 +1,9 @@
 package wrecker
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -58,18 +60,39 @@ func (w *Wrecker) Delete(endpoint string) *WreckerRequest {
 	return w.newRequest(DELETE, endpoint)
 }
 
-func (w *Wrecker) sendRequest(verb string, requestURL string, headers map[string]string, bodyParams url.Values, response interface{}) error {
-	// Preparing Request
-	paramsReader := strings.NewReader(bodyParams.Encode())
-	clientReq, err := http.NewRequest(verb, requestURL, paramsReader)
+func (w *Wrecker) sendRequest(r *WreckerRequest) error {
+
+	var contentType string
+	var bodyReader io.Reader
+	var err error
+
+	// Empty Body means that we're posting Params via Form encoding
+	if r.Body == nil {
+
+		bodyReader = strings.NewReader(r.Params.Encode())
+		contentType = w.DefaultContentType
+
+	} else {
+
+		// Otherwise, we're sending a request body
+		if bodyReader, err = prepareRequestBody(r.Body); err != nil {
+			return err
+		}
+
+		contentType = "application/json"
+	}
+
+	// Create the HTTP client request
+	clientReq, err := http.NewRequest(r.HttpVerb, r.URL(), bodyReader)
 	if err != nil {
 		return err
 	}
-	clientReq.Header.Add("Content-Type", w.DefaultContentType)
+
+	clientReq.Header.Add("Content-Type", contentType)
 
 	// Add headers to clientReq
-	for index, value := range headers {
-		clientReq.Header.Add(index, value)
+	for key, value := range r.Headers {
+		clientReq.Header.Add(key, value)
 	}
 
 	// Executing request
@@ -84,6 +107,31 @@ func (w *Wrecker) sendRequest(verb string, requestURL string, headers map[string
 	if err != nil {
 		return err
 	}
-	err = json.Unmarshal(body, &response)
-	return err
+
+	return json.Unmarshal(body, r.Response)
+}
+
+// prepareRequestBody() function was originally included in the
+// github.com/franela/goreq application (which is also MIT licensed)
+func prepareRequestBody(b interface{}) (io.Reader, error) {
+	switch b.(type) {
+	case string:
+		// treat is as text
+		return strings.NewReader(b.(string)), nil
+	case io.Reader:
+		// treat is as text
+		return b.(io.Reader), nil
+	case []byte:
+		//treat as byte array
+		return bytes.NewReader(b.([]byte)), nil
+	case nil:
+		return nil, nil
+	default:
+		// try to jsonify it
+		j, err := json.Marshal(b)
+		if err == nil {
+			return bytes.NewReader(j), nil
+		}
+		return nil, err
+	}
 }


### PR DESCRIPTION
This checkin adds a “WithBody” function and enables Wrecker to post
JSON-encoded documents directly to a REST web service.

In the process, we’re simplifying the signature of the sendRequest()
function by simply passing in the entire WreckerRequest object.
