### PR TITLE
Rename to wrecker.Request

### DIFF
--- a/request.go
+++ b/request.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 )
 
-type WreckerRequest struct {
+type Request struct {
 	HttpVerb      string
 	Endpoint      string
 	Response      interface{}
@@ -16,27 +16,27 @@ type WreckerRequest struct {
 	WreckerClient *Wrecker
 }
 
-func (r *WreckerRequest) WithParam(key, value string) *WreckerRequest {
+func (r *Request) WithParam(key, value string) *Request {
 	r.Params.Add(key, value)
 	return r
 }
 
-func (r *WreckerRequest) WithHeader(key, value string) *WreckerRequest {
+func (r *Request) WithHeader(key, value string) *Request {
 	r.Headers[key] = value
 	return r
 }
 
-func (r *WreckerRequest) WithBody(body interface{}) *WreckerRequest {
+func (r *Request) WithBody(body interface{}) *Request {
 	r.Body = body
 	return r
 }
 
-func (r *WreckerRequest) Into(response interface{}) *WreckerRequest {
+func (r *Request) Into(response interface{}) *Request {
 	r.Response = response
 	return r
 }
 
-func (r *WreckerRequest) Execute() (*http.Response, error) {
+func (r *Request) Execute() (*http.Response, error) {
 	switch r.HttpVerb {
 
 	case GET, POST, PUT, DELETE:
@@ -47,7 +47,7 @@ func (r *WreckerRequest) Execute() (*http.Response, error) {
 	}
 }
 
-func (r *WreckerRequest) URL() string {
+func (r *Request) URL() string {
 	result := r.WreckerClient.BaseURL + r.Endpoint
 
 	if (r.HttpVerb == "GET") && (len(r.Params) > 0) {

--- a/wrecker.go
+++ b/wrecker.go
@@ -34,8 +34,8 @@ const (
 	DELETE = "DELETE"
 )
 
-func (w *Wrecker) newRequest(httpVerb string, endpoint string) *WreckerRequest {
-	return &WreckerRequest{
+func (w *Wrecker) newRequest(httpVerb string, endpoint string) *Request {
+	return &Request{
 		HttpVerb:      httpVerb,
 		Endpoint:      endpoint,
 		Params:        url.Values{},
@@ -44,23 +44,23 @@ func (w *Wrecker) newRequest(httpVerb string, endpoint string) *WreckerRequest {
 	}
 }
 
-func (w *Wrecker) Get(endpoint string) *WreckerRequest {
+func (w *Wrecker) Get(endpoint string) *Request {
 	return w.newRequest(GET, endpoint)
 }
 
-func (w *Wrecker) Post(endpoint string) *WreckerRequest {
+func (w *Wrecker) Post(endpoint string) *Request {
 	return w.newRequest(POST, endpoint)
 }
 
-func (w *Wrecker) Put(endpoint string) *WreckerRequest {
+func (w *Wrecker) Put(endpoint string) *Request {
 	return w.newRequest(PUT, endpoint)
 }
 
-func (w *Wrecker) Delete(endpoint string) *WreckerRequest {
+func (w *Wrecker) Delete(endpoint string) *Request {
 	return w.newRequest(DELETE, endpoint)
 }
 
-func (w *Wrecker) sendRequest(r *WreckerRequest) (*http.Response, error) {
+func (w *Wrecker) sendRequest(r *Request) (*http.Response, error) {
 	var contentType string
 	var bodyReader io.Reader
 	var err error


### PR DESCRIPTION
Addressing Issue #16.  As discussed in issue conversation, this should NOT change the public API, only the names of the Request struct that is used internally.
