### PR TITLE
Rename params

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Without digging too far into anything, here is what your requests will look like
 
 ```go
 wreckerClient.Get("/users").
-    Param("id", "1").
+    URLParam("id", "1").
     Into(&user).            // Loads the response into the user struct
     Execute()
 ```
@@ -73,7 +73,7 @@ Now that we have our struct and our instance of `Wrecker`, we're ready to actual
 user := User{}
 
 response, err := wreckerClient.Get("/users").
-    Param("id", "1").
+    URLParam("id", "1").
     Into(&user).
     Execute()
 

--- a/request.go
+++ b/request.go
@@ -10,19 +10,25 @@ type Request struct {
 	HttpVerb      string
 	Endpoint      string
 	Response      interface{}
-	Params        url.Values
+	URLParams     url.Values
+	FormParams    url.Values
 	HttpBody      interface{}
 	Headers       map[string]string
 	WreckerClient *Wrecker
 }
 
-func (r *Request) Param(key, value string) *Request {
-	r.Params.Add(key, value)
+func (r *Request) Header(key, value string) *Request {
+	r.Headers[key] = value
 	return r
 }
 
-func (r *Request) Header(key, value string) *Request {
-	r.Headers[key] = value
+func (r *Request) URLParam(key, value string) *Request {
+	r.URLParams.Add(key, value)
+	return r
+}
+
+func (r *Request) FormParam(key, value string) *Request {
+	r.FormParams.Add(key, value)
 	return r
 }
 
@@ -50,8 +56,9 @@ func (r *Request) Execute() (*http.Response, error) {
 func (r *Request) URL() string {
 	result := r.WreckerClient.BaseURL + r.Endpoint
 
-	if (r.HttpVerb == "GET") && (len(r.Params) > 0) {
-		result += "?" + r.Params.Encode()
+	if len(r.URLParams) > 0 {
+		result += "?" + r.URLParams.Encode()
 	}
+
 	return result
 }

--- a/test/server.go
+++ b/test/server.go
@@ -3,7 +3,6 @@ package test
 import (
 	"encoding/json"
 	"github.com/brandonromano/wrecker/test/models"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/julienschmidt/httprouter"
 	"net"
 	"net/http"
@@ -86,8 +85,6 @@ func PutUser(writer http.ResponseWriter, request *http.Request, params httproute
 	response := new(models.Response).Init()
 	defer response.Output(writer)
 
-	spew.Dump(request.Header.Get("Content-Type"))
-
 	if request.Header.Get("Content-Type") == "application/json" {
 
 		user := new(models.User)
@@ -101,10 +98,6 @@ func PutUser(writer http.ResponseWriter, request *http.Request, params httproute
 		response.Content = user
 
 	} else {
-
-		spew.Dump(request.FormValue("id"))
-		spew.Dump(request.FormValue("user_name"))
-		spew.Dump(request.FormValue("location"))
 
 		id, err := strconv.Atoi(request.FormValue("id"))
 		userName := request.FormValue("user_name")

--- a/test/server.go
+++ b/test/server.go
@@ -3,6 +3,7 @@ package test
 import (
 	"encoding/json"
 	"github.com/brandonromano/wrecker/test/models"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/julienschmidt/httprouter"
 	"net"
 	"net/http"
@@ -85,6 +86,8 @@ func PutUser(writer http.ResponseWriter, request *http.Request, params httproute
 	response := new(models.Response).Init()
 	defer response.Output(writer)
 
+	spew.Dump(request.Header.Get("Content-Type"))
+
 	if request.Header.Get("Content-Type") == "application/json" {
 
 		user := new(models.User)
@@ -98,6 +101,10 @@ func PutUser(writer http.ResponseWriter, request *http.Request, params httproute
 		response.Content = user
 
 	} else {
+
+		spew.Dump(request.FormValue("id"))
+		spew.Dump(request.FormValue("user_name"))
+		spew.Dump(request.FormValue("location"))
 
 		id, err := strconv.Atoi(request.FormValue("id"))
 		userName := request.FormValue("user_name")

--- a/test/wrecker_test.go
+++ b/test/wrecker_test.go
@@ -22,7 +22,7 @@ func TestSuccessfulGet(t *testing.T) {
 	}
 
 	httpResponse, err := wreckerClient.Get("/users").
-		Param("id", "1").
+		URLParam("id", "1").
 		Into(&response).
 		Execute()
 
@@ -56,9 +56,9 @@ func TestSuccessfulPost(t *testing.T) {
 	}
 
 	httpResponse, err := wreckerClient.Post("/users").
-		Param("id", "1").
-		Param("user_name", "BrandonRomano").
-		Param("location", "Brooklyn, NY").
+		FormParam("id", "1").
+		FormParam("user_name", "BrandonRomano").
+		FormParam("location", "Brooklyn, NY").
 		Into(&response).
 		Execute()
 
@@ -76,8 +76,8 @@ func TestFailPost(t *testing.T) {
 	}
 
 	httpResponse, err := wreckerClient.Post("/users").
-		Param("id", "1").
-		Param("user_name", "BrandonRomano").
+		FormParam("id", "1").
+		FormParam("user_name", "BrandonRomano").
 		Into(&response).
 		Execute()
 
@@ -95,8 +95,8 @@ func TestSuccessfulPut(t *testing.T) {
 
 	username := "BrandonRomano100"
 	httpResponse, err := wreckerClient.Put("/users").
-		Param("id", "1").
-		Param("user_name", username).
+		FormParam("id", "1").
+		FormParam("user_name", username).
 		Into(&response).
 		Execute()
 

--- a/wrecker.go
+++ b/wrecker.go
@@ -38,7 +38,8 @@ func (w *Wrecker) newRequest(httpVerb string, endpoint string) *Request {
 	return &Request{
 		HttpVerb:      httpVerb,
 		Endpoint:      endpoint,
-		Params:        url.Values{},
+		URLParams:     url.Values{},
+		FormParams:    url.Values{},
 		Headers:       make(map[string]string),
 		WreckerClient: w,
 	}
@@ -61,21 +62,33 @@ func (w *Wrecker) Delete(endpoint string) *Request {
 }
 
 func (w *Wrecker) sendRequest(r *Request) (*http.Response, error) {
-	var contentType string
+
+	var contentType string = "application/x-www-form-urlencoded"
 	var bodyReader io.Reader
 	var err error
 
-	// Empty Body means that we're posting Params via Form encoding
-	if r.HttpBody == nil {
-		bodyReader = strings.NewReader(r.Params.Encode())
-		contentType = w.DefaultContentType
-	} else {
-		// Otherwise, we're sending a request body
-		contentType = "application/json"
-		bodyReader, err = prepareRequestBody(r.HttpBody)
+	// GET methods don't have an HTTP Body.  For all other methods,
+	// it's time to defined the body content.
+	if r.HttpVerb != GET {
 
-		if err != nil {
-			return nil, err
+		if r.HttpBody != nil {
+
+			// Otherwise, try using a JSON encoded body that was given to us
+			contentType = "application/json"
+
+			// try to Marshal it as JSON
+			j, err := json.Marshal(r.HttpBody)
+
+			if err != nil {
+				return nil, err
+			}
+
+			bodyReader = bytes.NewReader(j)
+
+		} else {
+
+			// If there are Form Parameters, then let's use form
+			bodyReader = strings.NewReader(r.FormParams.Encode())
 		}
 	}
 
@@ -85,6 +98,7 @@ func (w *Wrecker) sendRequest(r *Request) (*http.Response, error) {
 		return nil, err
 	}
 
+	// Set Content-Type for this request
 	clientReq.Header.Add("Content-Type", contentType)
 
 	// Add headers to clientReq
@@ -107,15 +121,4 @@ func (w *Wrecker) sendRequest(r *Request) (*http.Response, error) {
 
 	err = json.Unmarshal(body, r.Response)
 	return resp, err
-}
-
-func prepareRequestBody(b interface{}) (io.Reader, error) {
-
-	// try to jsonify it
-	j, err := json.Marshal(b)
-
-	if err == nil {
-		return bytes.NewReader(j), nil
-	}
-	return nil, err
 }


### PR DESCRIPTION
This should do it.

One artifact of the way we're automatically handling Content-Types is that there's no use for the DefaultContentType.  We only work with "application/x-www-form-urlencoded" and "application/json". 

I've left the DefaultContentType variable alone for now, because it seems like we may use it again when we add a ContentType() function (from issue #15) or add additional encoders (like "application/xml" or multipart forms).
